### PR TITLE
virts-383

### DIFF
--- a/app/chain_api.py
+++ b/app/chain_api.py
@@ -16,7 +16,7 @@ class ChainApi:
     async def landing(self, request):
         await self.auth_svc.check_permissions(request)
         abilities = await self.data_svc.explode_abilities()
-        tactics = {a['technique']['tactic'] for a in abilities}
+        tactics = set([tactic for sublist in [eval(a['technique']['tactic']) for a in abilities] for tactic in sublist])
         hosts = await self.data_svc.explode_agents()
         groups = list(set(([h['host_group'] for h in hosts])))
         adversaries = await self.data_svc.explode_adversaries()

--- a/static/js/sections.js
+++ b/static/js/sections.js
@@ -289,7 +289,7 @@ function buildAbility(ability, phase){
 
     template.find('#name').html(ability.name);
     template.find('#description').html(ability.description);
-    template.find('#ability-attack').html(ability.technique.tactic + ' | '+ ability.technique.attack_id + ' | '+ ability.technique.name);
+    template.find('#ability-attack').html(eval(ability.technique.tactic).join(" / ") + ' | '+ ability.technique.attack_id + ' | '+ ability.technique.name);
 
     if(requirements.length > 0) {
         template.find('#ability-metadata').append('<td><div id="ability-padlock"><div class="tooltip"><span class="tooltiptext">This ability has requirements</span>&#128274;</div></div></td>');
@@ -381,7 +381,7 @@ function populateTechniques(exploits){
     let found = [];
     let showing = [];
     exploits.forEach(function(ability) {
-        if(tactic == ability.technique.tactic && !found.includes(ability.technique.attack_id)) {
+        if(eval(ability.technique.tactic).includes(tactic) && !found.includes(ability.technique.attack_id)) {
             found.push(ability.technique.attack_id);
             appendTechniqueToList(tactic, ability);
             appendAbilityToList(ability);


### PR DESCRIPTION
Modifies handling and the adversary configuration interface to properly support multiple ATT&CK tactics per ATT&CK technique. See [T1105](https://attack.mitre.org/techniques/T1105/) for an example of why this is necessary.

Requires [data service changes](https://github.com/mitre/caldera/pull/359) to work.