### PR TITLE
New adversary button

### DIFF
--- a/static/js/sections.js
+++ b/static/js/sections.js
@@ -243,14 +243,14 @@ function downloadOperationReport() {
 /** ADVERSARIES **/
 
 function toggleAdversaryView() {
-    $('#viewAdversary, #new_phase').toggle();
-    $('#addAdversary').toggle();
+    $('#viewAdversary').toggle();
+    $('#addAdversary, #new_phase').toggle();
 
 
-    if ($('#togBtnOp').is(':checked')) {
-        showHide('.queueOption,#opBtn', '#adversaries');
+    if ($('#togBtnAd').is(':checked')) {
+        showHide('#addAdversary,#new_phase', '#viewAdversary');
     } else {
-        showHide('#adversaries', '.queueOption,#opBtn');
+        showHide('#viewAdversary', '#addAdversary,#new_phase');
     }
 }
 
@@ -259,7 +259,7 @@ function saveNewAdversary() {
     if(!name){alert('Please enter an adversary name!'); return; }
     let description = $('#profile-description').val();
     if(!description){alert('Please enter a description!'); return; }
-
+    
     let abilities = [];
     $('#profile-tests li').each(function() {
         abilities.push({"id": $(this).attr('id'),"phase":$(this).data('phase')})

--- a/static/js/sections.js
+++ b/static/js/sections.js
@@ -242,6 +242,18 @@ function downloadOperationReport() {
 
 /** ADVERSARIES **/
 
+function toggleAdversaryView() {
+    $('#viewAdversary, #new_phase').toggle();
+    $('#addAdversary').toggle();
+
+
+    if ($('#togBtnOp').is(':checked')) {
+        showHide('.queueOption,#opBtn', '#adversaries');
+    } else {
+        showHide('#adversaries', '.queueOption,#opBtn');
+    }
+}
+
 function saveNewAdversary() {
     let name = $('#profile-goal').val();
     if(!name){alert('Please enter an adversary name!'); return; }

--- a/templates/chain.html
+++ b/templates/chain.html
@@ -143,11 +143,11 @@
             <div class="row">
                 <div class="column section-border" style="flex:25%;">
                     <img src="/chain/img/hacker.png">
-                    <h4 style="margin-bottom:-15px">Adversaries</h4>
+                    <h4 >Adversaries</h4>
                     <br>
                     <div class="toggle">
                         <label class="switch">
-                            <input type="checkbox" id="togBtnOp" checked onchange="toggleAdversaryView()">
+                            <input type="checkbox" id="togBtnAd" checked onchange="toggleAdversaryView()">
                             <div class="slider round"><span class="on">VIEW</span><span class="off">NEW</span></div>
                         </label>
                     </div>
@@ -168,7 +168,7 @@
                             <option value="{{ s.facts | map(attribute='property') | list }}">{{ s.name }}</option>
                             {% endfor %}
                         </select>
-                        <button id="advNewBtn" type="button" class="button-notready atomic-button" onclick="saveNewAdversary()">Save / update</button>
+
                     </div>
         
                     <div id="addAdversary" style="display: none;">
@@ -191,7 +191,7 @@
                     <div id="dummy"></div>
         
                     <div id="new_phase" style="display: none;">
-                        <h4 class="phase-headers">Phase 1<span onclick="showPhaseModal(1)">✚</span><hr></h4>
+                        <h4 class="phase-headers">Phase 1&nbsp;&nbsp;&nbsp;<span onclick="showPhaseModal(1)">✚</span><hr></h4>
                         <div id="tempPhase1" style="" class="tempPhase">
                             <ul id="profile-tests" class="profile-tests"></ul>
                         </div>

--- a/templates/chain.html
+++ b/templates/chain.html
@@ -138,67 +138,70 @@
         </div>
 
         <!-- adversary -->
-       
-			<div id="adversary-profile" class="section-profile" style="display: none">
-          <div class="row">
-            <div class="column section-border" style="flex:25%;">
-              <img src="/chain/img/hacker.png">
-              <h4 style="margin-bottom:-15px">Adversaries</h4>
-              <br>
-               <div class="toggle">
-                <label class="switch"><input type="checkbox" id="togBtnOp" checked onchange="toggleAdversaryView()" >
-                  <div class="slider round"><span class="on">VIEW</span><span class="off">NEW</span></div>
-                </label>
-              </div>
-              <br>
-              <p class="section-description">
-                  Adversaries are collections of ATT&CK TTPs, designed to test specific threats.
-                  Abilities with unmet requirements are faded out to show the adversary cannot use them unless an
-                  unlocking ability is added.
-              </p>
-              <div id="viewAdversary">
-              	<select id="profile-existing-name" style="margin-top:-15px" onchange="loadAdversary();">
-                	<option value="" disabled selected>Select existing</option>
-               	 {% for adv in adversaries %}
-                    	<option value="{{ adv.id }}">{{ adv.name }}</option>
-               	 {% endfor %}}
-             	 </select>
-            	  <select id="advFactSource" onchange="refreshColorCodes()">
-             	   <option value="" selected>Overlay fact source</option>
-             	       {% for s in sources %}
-             	           <option value="{{ s.facts | map(attribute='property') | list }}">{{ s.name }}</option>
-             	       {% endfor %}
-      	        </select>
-                 <button id="advNewBtn" type="button" class="button-notready atomic-button" onclick="saveNewAdversary()">Save / update</button>
-              </div>
-              
-              <div id="addAdversary" style="display: none;">
-            	  <select id="advFactSource" onchange="refreshColorCodes()">
-             	   <option value="" selected>Overlay fact source</option>
-             	       {% for s in sources %}
-             	           <option value="{{ s.facts | map(attribute='property') | list }}">{{ s.name }}</option>
-             	       {% endfor %}
-      	        </select>
-                 <button id="advNewBtn" type="button" class="button-success atomic-button" onclick="saveNewAdversary()">Save new</button>
-              </div>
-
-            </div>
-            <div id="phases" class="column adversary-header" style="flex:75%;text-align: left">
-                <input id="profile-goal" type="text" class="advGoal" placeholder="Enter adversary name">
-                <input id="profile-description" type="text" placeholder="enter adversary description">
-                <br><br>
-               
-                <div id="dummy"></div>
-                
-                <div id="new_phase" style="display: none;">
-                	<h4 class="phase-headers">Phase 1<span onclick="showPhaseModal(1)">✚</span><hr></h4>
-                	<div id="tempPhase1" style="" class="tempPhase">
-                		<ul id="profile-tests" class="profile-tests"></ul>
-                	</div>
+        
+        <div id="adversary-profile" class="section-profile" style="display: none">
+            <div class="row">
+                <div class="column section-border" style="flex:25%;">
+                    <img src="/chain/img/hacker.png">
+                    <h4 style="margin-bottom:-15px">Adversaries</h4>
+                    <br>
+                    <div class="toggle">
+                        <label class="switch">
+                            <input type="checkbox" id="togBtnOp" checked onchange="toggleAdversaryView()">
+                            <div class="slider round"><span class="on">VIEW</span><span class="off">NEW</span></div>
+                        </label>
+                    </div>
+                    <p class="section-description" style="margin-top: 0px">
+                        Adversaries are collections of ATT&CK TTPs, designed to test specific threats. Abilities with unmet requirements are faded out to show the adversary cannot use them unless an unlocking ability is added.
+                    </p>
+        
+                    <div id="viewAdversary">
+                        <select id="profile-existing-name" onchange="loadAdversary();">
+                            <option value="" disabled selected>Select existing</option>
+                            {% for adv in adversaries %}
+                            <option value="{{ adv.id }}">{{ adv.name }}</option>
+                            {% endfor %}}
+                        </select>
+                        <select id="advFactSource" onchange="refreshColorCodes()">
+                            <option value="" selected>Overlay fact source</option>
+                            {% for s in sources %}
+                            <option value="{{ s.facts | map(attribute='property') | list }}">{{ s.name }}</option>
+                            {% endfor %}
+                        </select>
+                        <button id="advNewBtn" type="button" class="button-notready atomic-button" onclick="saveNewAdversary()">Save / update</button>
+                    </div>
+        
+                    <div id="addAdversary" style="display: none;">
+                        <select id="advFactSource" onchange="refreshColorCodes()">
+                            <option value="" selected>Overlay fact source</option>
+                            {% for s in sources %}
+                            <option value="{{ s.facts | map(attribute='property') | list }}">{{ s.name }}</option>
+                            {% endfor %}
+                        </select>
+                        <button id="advNewBtn" type="button" class="button-success atomic-button" onclick="saveNewAdversary()">Save new</button>
+                    </div>
+        
                 </div>
-             </div>
+                <div id="phases" class="column adversary-header" style="flex:75%;text-align: left">
+                    <input id="profile-goal" type="text" class="advGoal" placeholder="Enter adversary name">
+                    <input id="profile-description" type="text" placeholder="enter adversary description">
+                    <br>
+                    <br>
+        
+                    <div id="dummy"></div>
+        
+                    <div id="new_phase" style="display: none;">
+                        <h4 class="phase-headers">Phase 1<span onclick="showPhaseModal(1)">✚</span><hr></h4>
+                        <div id="tempPhase1" style="" class="tempPhase">
+                            <ul id="profile-tests" class="profile-tests"></ul>
+                        </div>
+                    </div>
+                </div>
             </div>
-          </div>        
+        </div>       
+
+
+
         
         
 

--- a/templates/chain.html
+++ b/templates/chain.html
@@ -138,39 +138,69 @@
         </div>
 
         <!-- adversary -->
-
-        <div id="adversary-profile" class="section-profile" style="display: none">
+       
+			<div id="adversary-profile" class="section-profile" style="display: none">
           <div class="row">
             <div class="column section-border" style="flex:25%;">
               <img src="/chain/img/hacker.png">
               <h4 style="margin-bottom:-15px">Adversaries</h4>
+              <br>
+               <div class="toggle">
+                <label class="switch"><input type="checkbox" id="togBtnOp" checked onchange="toggleAdversaryView()" >
+                  <div class="slider round"><span class="on">VIEW</span><span class="off">NEW</span></div>
+                </label>
+              </div>
+              <br>
               <p class="section-description">
                   Adversaries are collections of ATT&CK TTPs, designed to test specific threats.
                   Abilities with unmet requirements are faded out to show the adversary cannot use them unless an
                   unlocking ability is added.
               </p>
-              <select id="profile-existing-name" style="margin-top:-15px" onchange="loadAdversary();">
-                <option value="" disabled selected>Select an existing adversary</option>
-                {% for adv in adversaries %}
-                    <option value="{{ adv.id }}">{{ adv.name }}</option>
-                {% endfor %}}
-              </select>
-              <select id="advFactSource" onchange="refreshColorCodes()">
-                <option value="" selected>Overlay fact source</option>
-                    {% for s in sources %}
-                        <option value="{{ s.facts | map(attribute='property') | list }}">{{ s.name }}</option>
-                    {% endfor %}
-              </select>
-              <button id="advNewBtn" type="button" class="button-notready atomic-button" onclick="saveNewAdversary()">Save new</button>
+              <div id="viewAdversary">
+              	<select id="profile-existing-name" style="margin-top:-15px" onchange="loadAdversary();">
+                	<option value="" disabled selected>Select existing</option>
+               	 {% for adv in adversaries %}
+                    	<option value="{{ adv.id }}">{{ adv.name }}</option>
+               	 {% endfor %}}
+             	 </select>
+            	  <select id="advFactSource" onchange="refreshColorCodes()">
+             	   <option value="" selected>Overlay fact source</option>
+             	       {% for s in sources %}
+             	           <option value="{{ s.facts | map(attribute='property') | list }}">{{ s.name }}</option>
+             	       {% endfor %}
+      	        </select>
+                 <button id="advNewBtn" type="button" class="button-notready atomic-button" onclick="saveNewAdversary()">Save / update</button>
+              </div>
+              
+              <div id="addAdversary" style="display: none;">
+            	  <select id="advFactSource" onchange="refreshColorCodes()">
+             	   <option value="" selected>Overlay fact source</option>
+             	       {% for s in sources %}
+             	           <option value="{{ s.facts | map(attribute='property') | list }}">{{ s.name }}</option>
+             	       {% endfor %}
+      	        </select>
+                 <button id="advNewBtn" type="button" class="button-success atomic-button" onclick="saveNewAdversary()">Save new</button>
+              </div>
+
             </div>
             <div id="phases" class="column adversary-header" style="flex:75%;text-align: left">
-                <input id="profile-goal" type="text" class="advGoal">
-                <input id="profile-description" type="text">
+                <input id="profile-goal" type="text" class="advGoal" placeholder="Enter adversary name">
+                <input id="profile-description" type="text" placeholder="enter adversary description">
                 <br><br>
+               
                 <div id="dummy"></div>
+                
+                <div id="new_phase" style="display: none;">
+                	<h4 class="phase-headers">Phase 1<span onclick="showPhaseModal(1)">✚</span><hr></h4>
+                	<div id="tempPhase1" style="" class="tempPhase">
+                		<ul id="profile-tests" class="profile-tests"></ul>
+                	</div>
+                </div>
+             </div>
             </div>
-          </div>
-        </div>
+          </div>        
+        
+        
 
         <!-- templates -->
 


### PR DESCRIPTION
Added a toggle switch to change between adding a new, and editing an existing adversary.  

Needs a little bit of tidying at some point / additional ideas

- Placeholder text should probably be hidden in view existing mode (to add a new name / description)
- Ability to add new phases functionality should be added - needs some JS to do this.
- When moving from existing to a new adversary it should probably clear the abilities panel

Only tested in Chrome