### PR TITLE
GUI untrusted/trusted agents

### DIFF
--- a/app/chain_api.py
+++ b/app/chain_api.py
@@ -3,6 +3,7 @@ import asyncio
 from aiohttp import web
 from aiohttp_jinja2 import template
 
+from datetime import datetime
 
 class ChainApi:
 
@@ -79,4 +80,12 @@ class ChainApi:
 
         await _validate_request()
         await self.data_svc.update('core_operation', 'id', body['id'], dict(state=body.get('state')))
+        return web.Response()
+
+    async def rest_reset_trust(self, request):
+        await self.auth_svc.check_permissions(request)
+        untrusted_agents = await self.data_svc.explode_agents(criteria=dict(trusted=0))
+        now = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        for a in untrusted_agents:
+            await self.data_svc.update('core_agent', 'paw', a['paw'], data=dict(trusted=1, last_trusted_seen=now))
         return web.Response()

--- a/hook.py
+++ b/hook.py
@@ -12,3 +12,4 @@ async def initialize(app, services):
     app.router.add_route('*', '/plugin/chain/full', chain_api.rest_full)
     app.router.add_route('*', '/plugin/chain/rest', chain_api.rest_api)
     app.router.add_route('PUT', '/plugin/chain/operation/state', chain_api.rest_state_control)
+    app.router.add_route('PUT', '/plugin/chain/agents/trust', chain_api.rest_reset_trust)

--- a/static/js/sections.js
+++ b/static/js/sections.js
@@ -8,8 +8,15 @@ function saveGroups(){
     let data = $('#netTbl').DataTable().rows().data();
     data.each(function (value, index) {
         let group = document.getElementById(value[0]+'-group').value;
-        restRequest('PUT', {"index":"core_agent", "paw": value[0], "host_group": group});
+        restRequest('PUT', {"index":"core_agent", "paw": value[0], "host_group": group}, reloadLocation);
     });
+}
+
+function resetTrust(){
+    restRequest('PUT', {'index':'core_agent'}, reloadLocation, '/plugin/chain/agents/trust');
+}
+
+function reloadLocation(data){
     location.reload(true);
 }
 
@@ -65,7 +72,8 @@ function handleStartAction(){
         "planner":document.getElementById("queuePlanner").value,
         "stealth":document.getElementById("queueStealth").value,
         "jitter":jitter,
-        "sources":[document.getElementById("queueSource").value]
+        "sources":[document.getElementById("queueSource").value],
+        "allow_untrusted":document.getElementById("queueUntrusted").value
     };
     restRequest('PUT', queueDetails, handleStartActionCallback);
 }

--- a/templates/chain.html
+++ b/templates/chain.html
@@ -76,12 +76,14 @@
                   Groups are collections of agents so hosts can be compromised simultaneously.
               </p>
               <button id="addGroupBtn" type="button" class="button-success atomic-button" onclick="saveGroups()">Save changes</button>
+              <button id="setTrusted" type="button" class="button-success atomic-button" onclick="resetTrust();">Reset trust</button>
             </div>
             <div class="column" style="flex:75%">
               <table id="netTbl" class="display" style="width:100%;" >
                 <thead>
                 <tr>
                   <th>Host <i style="font-size:11px">paw print</i></th>
+                  <th>Status</th>
                   <th>Platform</th>
                   <th>Executor</th>
                   <th>Last seen</th>
@@ -93,6 +95,12 @@
                   {% for a in agents %}
                       <tr>
                         <td>{{ a.paw }}</td>
+                        {% if a.trusted == 1 %}
+                        <td style="color:#2bff00">trusted</td>
+                        {% endif %}
+                        {% if a.trusted == 0 %}
+                        <td style="color:#ff0000">untrusted</td>
+                        {% endif %}
                         <td>{{ a.platform }}</td>
                         <td>{% for e in a.executors  %}{{ e.executor }}<br />{% endfor %}</td>
                         <td>{{ a.last_seen }}</td>
@@ -269,6 +277,10 @@
                   <select name="stealth" id="queueStealth" class="queueOption" style="opacity:0.5" disabled="true" onchange="checkOpformValid()">
                     <option value="0" selected>Run normal operation</option>
                     <option value="1">Run stealth operation</option>
+                  </select>
+                  <select name="untrusted" id="queueUntrusted" class="queueOption" style="opacity:0.5" disabled="true" onchange="checkOpformValid()">
+                    <option value="0" selected>Not allow untrusted agents</option>
+                    <option value="1">Allow untrusted agents</option>
                   </select>
                   <input name="jitter" id="queueJitter" class="queueOption" placeholder="Jitter (min/max)" style="opacity:0.5;" disabled="true" helpinfo="jitterInfo" oninput="checkOpformValid()"/>
                   <button id="opBtn" type="button" style="opacity:0.5" disabled="true"


### PR DESCRIPTION
- Added a UI drop-down when starting an operation to allow running against untrusted agents or not
- Added status field in the agents section to see which ones are trusted and which are untrusted
- Added a button in the agents section to 'restore trust' to all untrusted agents
- Fixing quick bug in an agent's group change request (saveGroups() function in sections.js)