### PR TITLE
Virts 520 human loop toggle

### DIFF
--- a/app/chain_api.py
+++ b/app/chain_api.py
@@ -86,6 +86,11 @@ class ChainApi:
         await self.data_svc.update('core_operation', 'id', body['id'], dict(state=body.get('state')))
         return web.Response()
 
+    async def rest_update_autonomous(self, request):
+        body = await request.json()
+        await self.data_svc.update('core_operation', 'id', body['id'], dict(autonomous=body['autonomous']))
+        return web.Response()
+
     async def rest_reset_trust(self, request):
         await self.auth_svc.check_permissions(request)
         data = dict(await request.json())

--- a/app/chain_api.py
+++ b/app/chain_api.py
@@ -69,6 +69,12 @@ class ChainApi:
             self.loop.create_task(self.operation_svc.run(output))
         return output
 
+    async def rest_update_operation(self, request):
+        op_id = int(request.match_info['operation_id'])
+        data = await request.json()
+        await self.data_svc.update(table='core_operation', key='id', value=op_id, data=data)
+        return web.Response()
+
     async def rest_state_control(self, request):
         body = await request.json()
         state = body.get('state')
@@ -84,11 +90,6 @@ class ChainApi:
 
         await _validate_request()
         await self.data_svc.update('core_operation', 'id', body['id'], dict(state=body.get('state')))
-        return web.Response()
-
-    async def rest_update_autonomous(self, request):
-        body = await request.json()
-        await self.data_svc.update('core_operation', 'id', body['id'], dict(autonomous=body['autonomous']))
         return web.Response()
 
     async def rest_reset_trust(self, request):

--- a/hook.py
+++ b/hook.py
@@ -13,3 +13,5 @@ async def initialize(app, services):
     app.router.add_route('*', '/plugin/chain/rest', chain_api.rest_api)
     app.router.add_route('PUT', '/plugin/chain/operation/state', chain_api.rest_state_control)
     app.router.add_route('PUT', '/plugin/chain/agents/trust', chain_api.rest_reset_trust)
+    app.router.add_route('PUT', '/plugin/chain/operation/autonomous', chain_api.rest_update_autonomous)
+    app.router.add_route('PUT', '/plugin/chain/operation/<operation_id>', chain_api.rest_state_control)

--- a/hook.py
+++ b/hook.py
@@ -13,5 +13,4 @@ async def initialize(app, services):
     app.router.add_route('*', '/plugin/chain/rest', chain_api.rest_api)
     app.router.add_route('PUT', '/plugin/chain/operation/state', chain_api.rest_state_control)
     app.router.add_route('PUT', '/plugin/chain/agents/trust', chain_api.rest_reset_trust)
-    app.router.add_route('PUT', '/plugin/chain/operation/autonomous', chain_api.rest_update_autonomous)
-    app.router.add_route('PUT', '/plugin/chain/operation/<operation_id>', chain_api.rest_state_control)
+    app.router.add_route('PUT', '/plugin/chain/operation/{operation_id}', chain_api.rest_update_operation)

--- a/static/css/basic.css
+++ b/static/css/basic.css
@@ -322,27 +322,50 @@ table.dataTable input[type=text] {
 .watermarked {
   position: relative;
 }
-.op-control-text {
-    text-transform: uppercase;
-    background-color: var(--navbar-background);
-    padding: 5px 5px 5px 5px;
-    height: 30px;
-    text-align: center;
-    font-size: medium;
-    font-weight: bold;
-    width: 5%
+.op-control-container{
+    display: flex;
+    width: 50%;
+    justify-content: center;
 }
-.op-control button {
+.op-control-item{
     background-color: white;
     border: 2px solid var(--theme-color);
     height: 30px;
     border-radius: 10px;
     text-align: center;
     font-size: medium;
+    vertical-align: center;
+    width: 100%;
+    flex-grow: 1;
+    margin: 0 4px;
+}
+.op-control-text{
+    text-transform: uppercase;
+    background-color: var(--navbar-background);
+    padding: 5px 5px 5px 5px;
+    height: 30px;
+    text-align: center;
+    vertical-align: center;
+    font-size: large;
+    font-weight: bold;
     width: 5%
 }
+.op-control-item button {
+    background-color: white;
+    border: 2px solid var(--theme-color);
+    height: 30px;
+    border-radius: 10px;
+    text-align: center;
+    font-size: medium;
+    vertical-align: center;
+    width: 100%;
+    white-space: nowrap;
+}
+.op-control-item .large {
+    flex-grow: 2;
+}
 
-.op-control button:hover {
+.op-control-item button:hover {
     cursor: pointer;
 }
 .codearea textarea {

--- a/static/css/basic.css
+++ b/static/css/basic.css
@@ -141,6 +141,9 @@
     padding-bottom: 20px;
     text-transform: lowercase;
 }
+.op-selected {
+    visibility: hidden;
+}
 .op-dets img {
     border-radius: 50%;
     height:30px;

--- a/static/css/modal.css
+++ b/static/css/modal.css
@@ -78,6 +78,15 @@ span.psw {
     font-size: 35px;
     font-weight: bold;
 }
+.modal .approve{
+    background-color: green;
+}
+.modal .discard{
+    background-color: darkorange;
+}
+.modal .approveall{
+    background-color: darkgreen;
+}
 
 .close:hover,
 .close:focus {

--- a/static/js/sections.js
+++ b/static/js/sections.js
@@ -948,7 +948,9 @@ function hilApproveAll(){
             restRequest('PUT', data, doNothing);
         }
     }
-    toggleHil();
+    if (!OPERATION.autonomous){
+        toggleHil();
+    }
     refresh();
     return false;
 }

--- a/static/js/sections.js
+++ b/static/js/sections.js
@@ -928,13 +928,15 @@ function submitHilChanges(status){
     return false;
 }
 function toggleHil(){
-    let data = {id: $('#operation-list option:selected').attr('value')};
+    let op_id = $('#operation-list option:selected').attr('value');
+    let data = {};
     if(operation.autonomous){
         data['autonomous'] = 0;
     }else{
         data['autonomous'] = 1;
     }
-    restRequest('PUT', data, function(d){refresh()}, '/plugin/chain/operation/autonomous');
+    restRequest('PUT', data, function(d){refresh()}, `/plugin/chain/operation/${op_id}`);
+    // restRequest('PUT', data, function(d){refresh()}, '/plugin/chain/operation/autonomous');
 }
 function hilApproveAll(){
     document.getElementById("loop-modal").style.display = "none";

--- a/static/js/sections.js
+++ b/static/js/sections.js
@@ -276,7 +276,7 @@ function handleStartAction(){
 }
 function changeCurrentOperationState(newState){
     let selectedOperationId = $('#operation-list option:selected').attr('value');
-    if(operation.state === 'finished'){
+    if(OPERATION.state === 'finished'){
         alert('This operation has finished.');
         return;
     }
@@ -321,56 +321,56 @@ function clearTimeline() {
     });
 }
 
-let operation = {};
+let OPERATION = {};
 function operationCallback(data){
-    operation = data[0];
-    $("#op-control-state").html(operation.state);
-    if (operation.autonomous) {
+    OPERATION = data[0];
+    $("#op-control-state").html(OPERATION.state);
+    if (OPERATION.autonomous) {
         $("#togBtnHil").prop("checked", true);
-    }else{
+    } else {
         $("#togBtnHil").prop("checked", false);
     }
 
     clearTimeline();
-    for(let i=0;i<operation.chain.length;i++){
-        if(operation.chain[i].status === -1) {
-            $('#hil-linkId').html(operation.chain[i].id);
-            $('#hil-paw').html(trimPaw(operation.chain[i].paw));
-            $('#hil-command').html(atob(operation.chain[i].command));
+    for(let i=0; i<OPERATION.chain.length; i++){
+        if(OPERATION.chain[i].status === -1) {
+            $('#hil-linkId').html(OPERATION.chain[i].id);
+            $('#hil-paw').html(trimPaw(OPERATION.chain[i].paw));
+            $('#hil-command').html(atob(OPERATION.chain[i].command));
             document.getElementById("loop-modal").style.display = "block";
             return;
-        } else if($("#op_id_" + operation.chain[i].id).length === 0) {
+        } else if($("#op_id_" + OPERATION.chain[i].id).length === 0) {
             let template = $("#link-template").clone();
-            let ability = operation.abilities.filter(item => item.id === operation.chain[i].ability)[0];
-            template.find('#link-description').html(operation.chain[i].abilityDescription);
-            let title = operation.chain[i].abilityName;
-            if(operation.chain[i].cleanup) {
+            let ability = OPERATION.abilities.filter(item => item.id === OPERATION.chain[i].ability)[0];
+            template.find('#link-description').html(OPERATION.chain[i].abilityDescription);
+            let title = OPERATION.chain[i].abilityName;
+            if(OPERATION.chain[i].cleanup) {
                 title = title + " (CLEANUP)"
             }
-            let splitPaw = operation.chain[i].paw.split('$');
+            let splitPaw = OPERATION.chain[i].paw.split('$');
             template.find('#link-technique').html(ability.technique_id + '<span class="tooltiptext">' + ability.technique_name + '</span>');
-            template.attr("id", "op_id_" + operation.chain[i].id);
-            template.attr("operation", operation.chain[i].op_id);
-            template.attr("data-date", operation.chain[i].decide.split('.')[0]);
+            template.attr("id", "op_id_" + OPERATION.chain[i].id);
+            template.attr("operation", OPERATION.chain[i].op_id);
+            template.attr("data-date", OPERATION.chain[i].decide.split('.')[0]);
             template.find('#time-tactic').html('<div style="font-size: 13px;font-weight:100" ' +
-                'ondblclick="rollup('+operation.chain[i].id+')">'+ splitPaw[0]+'$'+splitPaw[1] + '... ' +
-                title + '<span id="'+operation.chain[i].id+'-rs" style="font-size:14px;float:right;display:none" ' +
-                'onclick="findResults(this, '+operation.chain[i].id+')"' +
-                'data-encoded-cmd="'+operation.chain[i].command+'"'+'>&#9733;</span>' +
-                '<span id="'+operation.chain[i].id+'-rm" style="font-size:11px;float:right" onclick="discard('+operation.chain[i].id+')">&#x274C;</span></div>');
-            template.find('#time-action').html(atob(operation.chain[i].command));
-            template.find('#time-executor').html(operation.chain[i].executor);
-            refreshUpdatableFields(operation.chain[i], template);
+                'ondblclick="rollup('+OPERATION.chain[i].id+')">'+ splitPaw[0]+'$'+splitPaw[1] + '... ' +
+                title + '<span id="'+OPERATION.chain[i].id+'-rs" style="font-size:14px;float:right;display:none" ' +
+                'onclick="findResults(this, '+OPERATION.chain[i].id+')"' +
+                'data-encoded-cmd="'+OPERATION.chain[i].command+'"'+'>&#9733;</span>' +
+                '<span id="'+OPERATION.chain[i].id+'-rm" style="font-size:11px;float:right" onclick="discard('+OPERATION.chain[i].id+')">&#x274C;</span></div>');
+            template.find('#time-action').html(atob(OPERATION.chain[i].command));
+            template.find('#time-executor').html(OPERATION.chain[i].executor);
+            refreshUpdatableFields(OPERATION.chain[i], template);
 
             template.insertBefore("#time-start");
             $(template.find("#inner-contents")).slideUp();
             template.show();
         } else {
-            let existing = $("#op_id_"+operation.chain[i].id);
-            refreshUpdatableFields(operation.chain[i], existing);
+            let existing = $("#op_id_"+OPERATION.chain[i].id);
+            refreshUpdatableFields(OPERATION.chain[i], existing);
         }
     }
-    if(operation.finish != null) {
+    if(OPERATION.finish != null) {
         console.log("Turning off refresh interval for page");
         clearInterval(atomic_interval);
         atomic_interval = null;
@@ -930,7 +930,7 @@ function submitHilChanges(status){
 function toggleHil(){
     let op_id = $('#operation-list option:selected').attr('value');
     let data = {};
-    if(operation.autonomous){
+    if(OPERATION.autonomous){
         data['autonomous'] = 0;
     }else{
         data['autonomous'] = 1;
@@ -940,8 +940,8 @@ function toggleHil(){
 function hilApproveAll(){
     document.getElementById("loop-modal").style.display = "none";
     let currentLinkId = $('#hil-linkId').html();
-    for(let i=0;i<operation.chain.length;i++){
-        let nextLink = operation.chain[i];
+    for(let i=0; i<OPERATION.chain.length; i++){
+        let nextLink = OPERATION.chain[i];
         if (nextLink.id >= currentLinkId){
             let data = {'index':'core_chain', 'key': 'id', 'value': nextLink.id, 'data': {'status': -3, 'command': nextLink.command}};
             restRequest('PUT', data, doNothing);

--- a/static/js/sections.js
+++ b/static/js/sections.js
@@ -304,6 +304,7 @@ function refresh() {
     let selectedOperationId = $('#operation-list option:selected').attr('value');
     let postData = selectedOperationId ? {'index':'core_operation','id': selectedOperationId} : null;
     if (selectedOperationId > 0){
+        $('.op-selected').css('visibility', 'visible');
         $('#downloadOperationReport').prop('disabled', false).css('opacity', 1.0);
     } else {
         $('#downloadOperationReport').prop('disabled', true).css('opacity', 0.5);

--- a/static/js/sections.js
+++ b/static/js/sections.js
@@ -936,15 +936,14 @@ function toggleHil(){
         data['autonomous'] = 1;
     }
     restRequest('PUT', data, function(d){refresh()}, `/plugin/chain/operation/${op_id}`);
-    // restRequest('PUT', data, function(d){refresh()}, '/plugin/chain/operation/autonomous');
 }
 function hilApproveAll(){
     document.getElementById("loop-modal").style.display = "none";
     let currentLinkId = $('#hil-linkId').html();
     for(let i=0;i<operation.chain.length;i++){
-        nextLink = operation.chain[i];
+        let nextLink = operation.chain[i];
         if (nextLink.id >= currentLinkId){
-            let data = {'index':'core_chain', 'key': 'id', 'value': nextLink.id, 'data': {'status': status, 'command': btoa(nextLink.command)}};
+            let data = {'index':'core_chain', 'key': 'id', 'value': nextLink.id, 'data': {'status': -3, 'command': nextLink.command}};
             restRequest('PUT', data, doNothing);
         }
     }

--- a/templates/chain.html
+++ b/templates/chain.html
@@ -349,7 +349,7 @@
                         <br>
                         <div class="toggle">
                             <label class="switch"><input type="checkbox" id="togBtnHil" onchange="toggleHil()">
-                                <div class="slider round"><span class="on">Autonomous</span><span class="off">Manual Approval</span></div>
+                                <div class="slider round"><span class="on">Autonomous&emsp;&emsp;</span><span class="off">Manual Approval</span></div>
                             </label>
                         </div>
                     </div>

--- a/templates/chain.html
+++ b/templates/chain.html
@@ -561,9 +561,10 @@
                         <div class="column" style="flex:25%">
                             <p id="hil-linkId"></p>
                             <h5 id="hil-paw"></h5>
-                            <button class="atomic-button button-success" type="button" onclick="submitHilChanges(-3)">Approve</button>
-                            <button class="atomic-button button-embedded" type="button" onclick="submitHilChanges(-2)">Discard</button>
-                            <button class="atomic-button button-embedded" type="button" onclick="hilApproveAll()">Approve All</button>
+                            <button class="atomic-button button-success approve" type="button" onclick="submitHilChanges(-3)">Approve</button>
+                            <button class="atomic-button button-embedded discard" type="button" onclick="submitHilChanges(-2)">Discard</button>
+                            <br><br>
+                            <button class="atomic-button approveall" type="button" onclick="hilApproveAll()">Approve All</button>
                         </div>
                         <div class="column codearea" style="flex:75%">
                             <textarea id="hil-command" spellcheck="false"></textarea>

--- a/templates/chain.html
+++ b/templates/chain.html
@@ -339,7 +339,7 @@
                   </button>
               </div>
             </div>
-            <div class="column" style="flex:75%">
+            <div class="column op-selected" style="flex:75%">
               <div class="op-dets">
                 <center>
                     <div class="op-control-container">

--- a/templates/chain.html
+++ b/templates/chain.html
@@ -342,12 +342,20 @@
             <div class="column" style="flex:75%">
               <div class="op-dets">
                 <center>
-                    <div class="op-control">
-                        <span title="Current Operation Status" class="op-control-text" id="op-control-state"></span>
-                        <span title="Pause Operation"><button id="op-control-pause" class="op-control" onclick="changeCurrentOperationState('paused')">&#2405;</button></span>
-                        <span title="Run One Step"><button id="run-one-link" class="op-control" onclick="changeCurrentOperationState('run_one_link')">&#9658;&#10072;</button></span>
-                        <span title="Run Operation"><button id="op-control-run" class="op-control" onclick="changeCurrentOperationState('running')">&#9658;</button></span>
+                    <div class="op-control-container">
+                        <span title="Pause Operation" class="op-control-item"><button id="op-control-pause" onclick="changeCurrentOperationState('paused')">&#2405;</button></span>
+                        <span title="Run One Step" class="op-control-item"><button id="run-one-link" onclick="changeCurrentOperationState('run_one_link')">&#9658;&#10072;</button></span>
+                        <span title="Run Operation" class="op-control-item"><button id="op-control-run" onclick="changeCurrentOperationState('running')">&#9658;</button></span>
+                        <br>
+                        <div class="toggle">
+                            <label class="switch"><input type="checkbox" id="togBtnHil" onchange="toggleHil()">
+                                <div class="slider round"><span class="on">Autonomous</span><span class="off">Manual Approval</span></div>
+                            </label>
+                        </div>
                     </div>
+                    <br>
+                    <span title="Current Operation Status" class="op-control-text" id="op-control-state"></span>
+                    <br>
                     <br>
                     <table class="legend">
                       <tr>
@@ -555,6 +563,7 @@
                             <h5 id="hil-paw"></h5>
                             <button class="atomic-button button-success" type="button" onclick="submitHilChanges(-3)">Approve</button>
                             <button class="atomic-button button-embedded" type="button" onclick="submitHilChanges(-2)">Discard</button>
+                            <button class="atomic-button button-embedded" type="button" onclick="hilApproveAll()">Approve All</button>
                         </div>
                         <div class="column codearea" style="flex:75%">
                             <textarea id="hil-command" spellcheck="false"></textarea>


### PR DESCRIPTION
Toggle autonomous operation during an operation. 

Changes: 
* Add toggle to operation control to allow switching between autonomous and human-in-the-loop. 
* Add an 'Approve All' button to the human-in-the-loop modal that approves all queued links and switches the operation to be autonomous
* Add API endpoint to chain that allow modifying an existing operation. 
* the operation object in section.js is now an outer-scope variable -- this seemed simpler than other approaches, but there might be a good argument I haven't thought of against doing it like this . 

Gotchas: 
* If you start an operation in human-in-the-loop mode and then switch to autonomous mode during the operation, you will still be prompted to approve cleanup actions.  This core PR has a fix for this: https://github.com/mitre/caldera/pull/561 . 