### PR TITLE
ability search for payloads

### DIFF
--- a/static/js/sections.js
+++ b/static/js/sections.js
@@ -718,10 +718,8 @@ function searchAbilities(parentId, exploits) {
     if(abilitySearch.val()) {
         exploits = addPlatforms(exploits);
         exploits.forEach(function(ability) {
-            ability['test'] = atob(ability.test);
             ability['cleanup'] = atob(ability.cleanup);
             if(JSON.stringify(ability).toLowerCase().includes(abilitySearch.val().toLowerCase())) {
-                ability['test'] = btoa(ability.test);
                 ability['cleanup'] = btoa(ability.cleanup);
                 appendAbilityToList(parentId, ability);
                 showing += 1;


### PR DESCRIPTION
Changes: 
* ability search now looks over the full 'test' / ability definition so that it can match payloads. 

Thoughts:
Originally, we were preventing searching over the full body of the Ability, but I think it's probably useful and reasonable to be able to do so.  We can scope it down again if we feel that search results are too large / unusable. 